### PR TITLE
Improve add batch async method

### DIFF
--- a/Azure.TableStorage.Repository/Azure.TableStorage.Repository/AzureTableStorage.cs
+++ b/Azure.TableStorage.Repository/Azure.TableStorage.Repository/AzureTableStorage.cs
@@ -143,7 +143,6 @@ namespace Wolnik.Azure.TableStorage.Repository
             var tasks = new List<Task<IList<TableResult>>>();
 
             var entitiesOffset = 0;
-
             while (entitiesOffset < entities?.Count())
             {
                 var entitiesToAdd = entities.Skip(entitiesOffset).Take(100).ToList();


### PR DESCRIPTION
Hi,

this is new pull request for method **AddBatchAsync**

**It fixes:**
- return type from method

**It improves:**
- possibility to add batch more than 100 entities in single invoke, which is standard limit from Azure Table Storage for single ExecuteBatch operation.

The time that method takes to add around 500 records is 1-1,3 second.

The thing I'm not sure is the most efficient way of dividing entites into batches, but the one is used now in pull request is pretty fast.

The other possible approach is:
```
            var groupedEntitiesToAdd = entities.Select((entity, index) => new { entity, index })
                .GroupBy(x => x.index / 100)
                .Select(grouping => grouping.Select(x => x.entity))
                .ToList();

            foreach (var groupedEntity in groupedEntitiesToAdd)
            {
                TableBatchOperation batchOperation = new TableBatchOperation();
                foreach (var entity in groupedEntity)
                {
                    batchOperation.Insert(entity);
                }
                tasks.Add(table.ExecuteBatchAsync(batchOperation));
            }
``` 

But here GroupBy makes first full iteration on collection, and Skip and Take are just math operations so I chose this. Time of execution both is almost the same tough.